### PR TITLE
Adopt NPF readiness Tier 1 baseline (dscgp)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,38 @@
+# GitHub Copilot instructions — microsoft/purview-api-samples
+
+This file points coding agents at the repo's canonical guidance. **Start with
+[`AGENTS.md`](../AGENTS.md)** for the sample map, entry points, verification, and
+guardrails.
+
+## Repo shape
+
+A multi-sample collection of independent Microsoft Purview developer samples
+(PowerShell, .NET 8 WPF, Python/AWS Lambda, a browser frontend, and a Postman
+collection). There is no single buildable service; each top-level folder is its
+own sample with its own README.
+
+## Before you change anything
+
+- Read the affected sample's README and [`docs/conventions.md`](../docs/conventions.md).
+- Keep edits scoped to one sample per PR; avoid cross-sample refactors.
+- Never hard-code secrets, tenant IDs, or client IDs — use placeholders and the
+  patterns already ignored in [`.gitignore`](../.gitignore).
+
+## Verify before you commit
+
+Run [`scripts/verify.ps1`](../scripts/verify.ps1) from the repo root. It must
+pass. See [`docs/build-and-test.md`](../docs/build-and-test.md) for per-sample
+commands.
+
+## PR-size guardrails
+
+- Prefer small, single-purpose PRs (roughly < 400 changed lines); split larger
+  work into reviewable steps.
+- One sample per PR where practical; call out cross-cutting changes explicitly.
+- Update the touched sample's README in the same PR when behavior changes.
+
+## Telemetry tagging (mandatory)
+
+Apply the labels and the description-footer block defined in
+[`.github/instructions/telemetry.instructions.md`](instructions/telemetry.instructions.md)
+to every PR and ADO work item, on every turn.

--- a/.github/instructions/telemetry.instructions.md
+++ b/.github/instructions/telemetry.instructions.md
@@ -1,0 +1,116 @@
+---
+applyTo: "**"
+authority: canonical
+applies-to: microsoft/purview-api-samples
+last-reviewed: 2026-06-29
+owners: microsoft/purview-api-samples maintainers
+---
+# PR & ADO Work Item Telemetry Tagging — MANDATORY
+
+> This section is the authoritative source of truth for how **PRs *and* ADO
+> work items** (Tasks, Bugs, User Stories) get tagged. Any agent (Copilot
+> CLI, Copilot Chat, Claude, Cursor, etc.) that drafts, edits, or completes
+> a PR **or** a work item in this repo **must** apply the rules below on
+> every turn — not just the first one. Tags drive Kusto telemetry
+> (`AzureDevOpsPullRequest` + `AzureDevOpsWorkItem`) for M4-level
+> agentic-vs-manual reporting.
+
+> **PR and work-item titles are left to the author's discretion** — no
+> required prefix. Tags live in labels/Tags + description footer only. The
+> exact tokens below are what Kusto dashboards filter on — do not use
+> synonyms (`ai`, `copilot`, `bugfix`, etc.) as anything else is invisible.
+
+## 1. PR labels (required)
+
+Apply two ADO labels on every PR:
+- one of: `agentic-cli`, `agentic-ide`, `agentic-mixed`, `manual`
+  - `agentic-cli` — Copilot CLI / Claude CLI / any terminal agent drove the bulk of the edits
+  - `agentic-ide` — Copilot Chat / Cursor / inline-suggest in VS Code / Visual Studio drove the bulk of the edits
+  - `agentic-mixed` — agent + meaningful hand-edits (≥ ~20% human-authored lines)
+  - `manual` — no agent involvement, or agent used only for trivial completions
+- one of: `bug`, `hotfix`, `feature`, `refactor`, `test`, `docs`, `security`, `infra`, `telemetry`, `chore`
+
+Labels survive squash-merge and are queryable via the `Labels` column in the
+`AzureDevOpsPullRequest` Kusto table.
+
+## 2. PR description footer (required)
+
+Append this fenced block to the end of every PR description. Keep the
+sentinels intact — a downstream pipeline relies on them:
+
+```
+<!-- BEGIN pr-telemetry -->
+assistance: <agentic-cli|agentic-ide|agentic-mixed|manual>
+type: <bug|hotfix|feature|refactor|test|docs|security|infra|telemetry|chore>
+agent-tool: <copilot-cli|copilot-chat|claude-cli|cursor|other|n/a>
+agent-model: <e.g. claude-opus-4.7, gpt-5, n/a>
+work-item: AB#<id or n/a>
+<!-- END pr-telemetry -->
+```
+
+If you cannot determine the model, use `n/a`. Never omit the block.
+
+## 3. ADO work-item Tags (required)
+
+Whenever you create or update an ADO work item (Task, Bug, User Story,
+Feature), populate the built-in **Tags** field with exactly two tokens
+from the same vocabularies used on PRs:
+
+- one of: `agentic-cli`, `agentic-ide`, `agentic-mixed`, `manual`
+  - Same semantics as PR labels — describes who/what drove the **work
+    tracked by this item** (planning + execution), not just the PR that
+    closes it.
+- one of: `bug`, `hotfix`, `feature`, `refactor`, `test`, `docs`, `security`, `infra`, `telemetry`, `chore`
+  - Match the work-item intent. For a `Bug` work-item type the tag is
+    almost always `bug` or `hotfix`; for a `Task` it follows the change.
+
+ADO work-item Tags are semicolon-separated in the UI and surface in the
+`Tags` / `System.Tags` column of the `AzureDevOpsWorkItem` Kusto table.
+Apply both tokens — missing either one drops the item from the dashboard.
+
+## 4. ADO work-item description footer (required)
+
+Append this fenced block to the **end of the work-item Description**
+(HTML-friendly — ADO renders fenced blocks as `<pre>`). Keep the sentinels
+intact:
+
+```
+<!-- BEGIN wit-telemetry -->
+assistance: <agentic-cli|agentic-ide|agentic-mixed|manual>
+type: <bug|hotfix|feature|refactor|test|docs|security|infra|telemetry|chore>
+agent-tool: <copilot-cli|copilot-chat|claude-cli|cursor|other|n/a>
+agent-model: <e.g. claude-opus-4.7, gpt-5, n/a>
+related-pr: <PR id or n/a>
+<!-- END wit-telemetry -->
+```
+
+If the work item pre-dates the PR, set `related-pr: n/a` and update it to
+the PR id (e.g., `related-pr: 5120627`) when the PR is opened. Values for
+`assistance` / `type` on the work item and its linked PR should normally
+match; if they legitimately differ (e.g., human-planned Task, agent-drafted
+PR), each item declares its own truth — do not force them to agree.
+
+## 5. Self-declaration rule (agents only)
+
+When **you** (an AI agent) are the one creating or updating a PR **or** a
+work item, you **must** set `assistance` to one of the `agentic-*` values
+— never `manual`. The `manual` value is reserved for items a human drafted
+without agent help.
+
+If a human later hand-edits an agent-authored PR or work item
+significantly, upgrade `assistance` to `agentic-mixed`. Never downgrade an
+`agentic-*` tag to `manual`.
+
+## 6. Preservation rule
+
+- Never remove labels, Tags, or footer entries a human or prior agent
+  already set — on PRs **or** work items.
+- Only apply/upgrade — never delete or downgrade.
+
+## 7. When uncertain
+
+If the change legitimately spans two types (e.g., a refactor that also
+fixes a bug), pick the one the reviewer will care about more and note the
+secondary intent in the PR or work-item description. **Do not invent new
+tag values** and **do not skip tagging** — ask the user which type to pick
+if you truly cannot decide.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,57 @@
+# AGENTS.md — Repo router for microsoft/purview-api-samples
+
+> Short router / table of contents for humans and coding agents. This repo is a
+> **multi-sample collection** of independent Microsoft Purview developer
+> samples — there is no single buildable service. Each sample is self-contained
+> with its own README, prerequisites, and run instructions.
+
+## What this repo is
+
+Samples that show how to call the Microsoft Purview APIs in Microsoft Graph to
+support data security, compliance, and governance. See [`README.md`](./README.md)
+for the canonical sample list.
+
+## Samples (entry points)
+
+| Sample | Stack | Entry point | Docs |
+|--------|-------|-------------|------|
+| AWSBedrock | Python 3.12 (AWS Lambda) + browser MSAL frontend + CloudFormation | [`AWSBedrock/lambda/lambda_function.py`](./AWSBedrock/lambda/lambda_function.py), [`AWSBedrock/frontend/serve.py`](./AWSBedrock/frontend/serve.py) | [`AWSBedrock/README.md`](./AWSBedrock/README.md) |
+| DLPforCustomAIApps | PowerShell 7+ | [`DLPforCustomAIApps/Create-DlpPolicyForCustomAIApps.ps1`](./DLPforCustomAIApps/Create-DlpPolicyForCustomAIApps.ps1) | [`DLPforCustomAIApps/README.md`](./DLPforCustomAIApps/README.md) |
+| Foundry | Windows PowerShell 5.1 / PowerShell 7+ (`Az.Accounts`) | [`Foundry/EnableFoundryPurview.ps1`](./Foundry/EnableFoundryPurview.ps1) | [`Foundry/README.md`](./Foundry/README.md) |
+| Postman Collection | Postman / JSON | [`Postman Collection/DSPM4AI_API_postman_collection.json`](./Postman%20Collection/DSPM4AI_API_postman_collection.json) | [`Postman Collection/README.MD`](./Postman%20Collection/README.MD) |
+| dotnet/Desktop | .NET 8 WPF (`net8.0-windows`) | [`dotnet/Desktop/Purview API Explorer.sln`](./dotnet/Desktop/) | [`dotnet/Desktop/README.MD`](./dotnet/Desktop/README.MD) |
+
+## Conventions
+
+See [`docs/conventions.md`](./docs/conventions.md) for observed code-style and
+structure conventions, and [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the CLA and
+Code of Conduct process.
+
+## Verification / Definition of Done
+
+This repo has no CI pipeline and no single build. Use the repo-level verify loop
+to sanity-check all samples without deploying any of them:
+
+- Run [`scripts/verify.ps1`](./scripts/verify.ps1) — parses every PowerShell
+  script, byte-checks JSON samples, compiles the Python sources, and (when the
+  .NET SDK is available) builds the WPF solution.
+- See [`docs/build-and-test.md`](./docs/build-and-test.md) for the per-sample
+  build/test/run commands (the documented form of the verify loop).
+
+A change is **done** when `scripts/verify.ps1` passes and the touched sample's
+own README steps still hold.
+
+## PR conventions / telemetry (mandatory)
+
+Every PR **and** ADO work item must follow the tagging rules in
+[`.github/instructions/telemetry.instructions.md`](./.github/instructions/telemetry.instructions.md).
+Apply the required labels and the description footer block on every turn.
+
+## Guardrails for agents
+
+- Keep changes scoped to a single sample where possible; do not refactor across
+  samples in one PR.
+- Never commit real tenant IDs, client secrets, or cloud credentials — see
+  [`.gitignore`](./.gitignore) and `.env.example`. Use placeholders.
+- Keep PRs small and reviewable (see
+  [`.github/copilot-instructions.md`](./.github/copilot-instructions.md)).

--- a/agency.toml
+++ b/agency.toml
@@ -1,0 +1,55 @@
+# agency.toml — machine-readable context for microsoft/purview-api-samples
+# This repo is a multi-sample collection (no single buildable service).
+# See AGENTS.md for the human-readable router.
+
+[repo]
+name = "purview-api-samples"
+owner = "microsoft"
+description = "Samples for calling the Microsoft Purview APIs in Microsoft Graph for data security, compliance, and governance."
+kind = "multi-sample-collection"
+default_branch = "main"
+
+[readiness]
+dashboard_org = "dscgp"
+tier_target = "baseline_ready"
+source_skill = "npf-readiness-adopt"
+
+[verify]
+# Repo-level verify loop. No CI is configured for this repo.
+command = "pwsh ./scripts/verify.ps1"
+docs = "docs/build-and-test.md"
+
+[[samples]]
+name = "AWSBedrock"
+path = "AWSBedrock"
+stack = ["python", "aws-lambda", "cloudformation", "browser-msal"]
+entry_points = ["AWSBedrock/lambda/lambda_function.py", "AWSBedrock/frontend/serve.py"]
+readme = "AWSBedrock/README.md"
+
+[[samples]]
+name = "DLPforCustomAIApps"
+path = "DLPforCustomAIApps"
+stack = ["powershell"]
+entry_points = ["DLPforCustomAIApps/Create-DlpPolicyForCustomAIApps.ps1"]
+readme = "DLPforCustomAIApps/README.md"
+
+[[samples]]
+name = "Foundry"
+path = "Foundry"
+stack = ["powershell", "az.accounts"]
+entry_points = ["Foundry/EnableFoundryPurview.ps1"]
+readme = "Foundry/README.md"
+
+[[samples]]
+name = "Postman Collection"
+path = "Postman Collection"
+stack = ["postman", "json"]
+entry_points = ["Postman Collection/DSPM4AI_API_postman_collection.json"]
+readme = "Postman Collection/README.MD"
+
+[[samples]]
+name = "dotnet/Desktop"
+path = "dotnet/Desktop"
+stack = ["dotnet", "net8.0-windows", "wpf"]
+entry_points = ["dotnet/Desktop/Purview API Explorer.sln"]
+readme = "dotnet/Desktop/README.MD"

--- a/docs/build-and-test.md
+++ b/docs/build-and-test.md
@@ -1,0 +1,73 @@
+# Build & test (verify loop) — microsoft/purview-api-samples
+
+This repo is a collection of independent samples with **no single build and no
+CI**. The repo-level verify loop sanity-checks every sample without deploying
+anything to a cloud.
+
+## Repo-level verify
+
+From the repo root:
+
+```powershell
+pwsh ./scripts/verify.ps1
+```
+
+`scripts/verify.ps1` runs these offline, non-deploying checks:
+
+1. **PowerShell** — parses every `*.ps1` with the PowerShell language parser
+   (syntax/tokenizer check; no execution).
+2. **JSON** — validates each `*.json` sample (e.g. the Postman collection) parses.
+3. **Python** — byte-compiles the Python sources (`py_compile`) when Python is
+   available.
+4. **.NET** — `dotnet build` of `dotnet/Desktop/Purview API Explorer.sln` when
+   the .NET SDK is available (skipped with a warning if `dotnet` is missing or
+   offline restore fails). Pass `-SkipDotnetBuild` to skip it explicitly.
+
+The script exits non-zero if any required check fails.
+
+## Per-sample commands
+
+### AWSBedrock (Python Lambda + frontend)
+
+```bash
+# Lambda dependencies
+cd AWSBedrock/lambda && pip install -r requirements.txt
+# Run the frontend locally (serves http://localhost:8080)
+cd AWSBedrock/frontend && python serve.py
+```
+
+Full deploy (AWS account required) is documented in
+[`AWSBedrock/README.md`](../AWSBedrock/README.md).
+
+### DLPforCustomAIApps (PowerShell)
+
+```powershell
+Install-Module ExchangeOnlineManagement -Scope CurrentUser
+./DLPforCustomAIApps/Create-DlpPolicyForCustomAIApps.ps1
+```
+
+### Foundry (PowerShell)
+
+```powershell
+Install-Module -Name Az.Accounts -Scope CurrentUser -Force
+./Foundry/EnableFoundryPurview.ps1
+```
+
+### Postman Collection
+
+Import `Postman Collection/DSPM4AI_API_postman_collection.json` into Postman and
+configure OAuth 2.0 as described in
+[`Postman Collection/README.MD`](../Postman%20Collection/README.MD).
+
+### dotnet/Desktop (.NET 8 WPF — Windows)
+
+```powershell
+dotnet build "dotnet/Desktop/Purview API Explorer.sln"
+dotnet run --project "dotnet/Desktop/Purview API Explorer.csproj"
+```
+
+## Notes
+
+- These samples call live Microsoft Purview / Graph / Azure / AWS endpoints and
+  require real credentials to run end-to-end. The verify loop deliberately stops
+  at static validation and local build so it is safe to run in CI or offline.

--- a/docs/conventions.md
+++ b/docs/conventions.md
@@ -1,0 +1,54 @@
+# Conventions — microsoft/purview-api-samples
+
+Observed conventions for this multi-sample repo. These describe what the samples
+already do, so new contributions stay consistent. For the CLA and Code of
+Conduct process, see [`CONTRIBUTING.md`](../CONTRIBUTING.md).
+
+## Repository layout
+
+- One top-level folder per sample (`AWSBedrock/`, `DLPforCustomAIApps/`,
+  `Foundry/`, `Postman Collection/`, `dotnet/Desktop/`).
+- Every sample ships a `README.md` (or `README.MD`) with Overview, Prerequisites,
+  and run/test steps. New samples follow the same structure.
+- Community-health and license files (`CONTRIBUTING.md`, `SECURITY.md`,
+  `CODE_OF_CONDUCT.md`, `SUPPORT.md`, `LICENSE.txt`) live at the repo root only.
+
+## Secrets and configuration
+
+- Never commit real tenant IDs, client IDs, client secrets, or cloud
+  credentials. The root [`.gitignore`](../.gitignore) excludes `.env`, `.env.*`
+  (except `.env.example`), `*.pem`, `*.key`, `*.pfx`, and `secrets.json`.
+- Provide configuration as placeholders the user replaces (e.g.
+  `<your-client-id>`, `<your-tenant-id>`), as in `AWSBedrock/.env.example` and
+  the AWSBedrock README.
+- Test data must use clearly fake sensitive values (e.g. `4111-1111-1111-1111`),
+  matching the existing samples.
+
+## PowerShell samples (`DLPforCustomAIApps`, `Foundry`, `AWSBedrock/*.ps1`)
+
+- Target **PowerShell 7+** (Foundry also supports Windows PowerShell 5.1).
+- Keep a clearly labeled `Configuration` block of variables near the top of the
+  script for values users edit, as in `Create-DlpPolicyForCustomAIApps.ps1`.
+- Use approved-verb cmdlet patterns (`New-*`/`Set-*`/`Get-*`/`Remove-*`) and
+  print the resulting objects for verification.
+- Surface optional behavior via parameters (e.g. Foundry's `-Output`,
+  `-FilterOpenAiSubscriptions`).
+
+## .NET sample (`dotnet/Desktop`)
+
+- Target framework `net8.0-windows`, WPF, `Nullable` and `ImplicitUsings`
+  enabled (see `Purview API Explorer.csproj`).
+- Pin NuGet package versions explicitly in the `.csproj`.
+
+## Python sample (`AWSBedrock/lambda`, `AWSBedrock/frontend`)
+
+- Python 3.9+ (Lambda runtime 3.12). Declare dependencies in `requirements.txt`.
+- Follow the existing fail-closed governance pattern (do not log full prompts or
+  responses; make DLP decisions under the signed-in user's identity).
+
+## Documentation style
+
+- Markdown with a top-level `#` title, an Overview/What-it-does section, a
+  Prerequisites section, and explicit run/test commands in fenced code blocks.
+- Link to official `learn.microsoft.com` docs for APIs and cmdlets rather than
+  duplicating their content.

--- a/scripts/verify.ps1
+++ b/scripts/verify.ps1
@@ -1,0 +1,111 @@
+#!/usr/bin/env pwsh
+<#
+.SYNOPSIS
+    Repo-level verify loop for microsoft/purview-api-samples.
+
+.DESCRIPTION
+    This repo is a collection of independent samples with no single build and no
+    CI. This script runs offline, non-deploying checks across every sample:
+      1. PowerShell  - parse every *.ps1 (syntax check, no execution)
+      2. JSON        - validate every *.json sample parses
+      3. Python      - byte-compile Python sources (py_compile) when available
+      4. .NET        - dotnet build the WPF solution when the SDK is available
+
+    Exits non-zero if any required check fails. See docs/build-and-test.md.
+
+.PARAMETER SkipDotnetBuild
+    Skip the .NET build step (useful offline or where the SDK is unavailable).
+#>
+[CmdletBinding()]
+param(
+    [switch]$SkipDotnetBuild
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+Push-Location $repoRoot
+
+$failures = New-Object System.Collections.Generic.List[string]
+$warnings = New-Object System.Collections.Generic.List[string]
+
+function Write-Section($name) { Write-Host "`n=== $name ===" -ForegroundColor Cyan }
+
+# Exclude VCS and build output directories
+function Get-RepoFiles($pattern) {
+    Get-ChildItem -Path $repoRoot -Recurse -File -Filter $pattern -ErrorAction SilentlyContinue |
+        Where-Object { $_.FullName -notmatch '\\(\.git|bin|obj|node_modules|__pycache__)\\' }
+}
+
+# 1. PowerShell syntax
+Write-Section 'PowerShell syntax'
+foreach ($f in Get-RepoFiles '*.ps1') {
+    $tokens = $null; $errors = $null
+    [void][System.Management.Automation.Language.Parser]::ParseFile($f.FullName, [ref]$tokens, [ref]$errors)
+    if ($errors -and $errors.Count -gt 0) {
+        $failures.Add("PowerShell parse failed: $($f.FullName) ($($errors.Count) error(s))")
+        Write-Host "  FAIL $($f.Name)" -ForegroundColor Red
+    } else {
+        Write-Host "  ok   $($f.Name)" -ForegroundColor Green
+    }
+}
+
+# 2. JSON validity
+Write-Section 'JSON validity'
+foreach ($f in Get-RepoFiles '*.json') {
+    try {
+        Get-Content -Raw -Path $f.FullName | ConvertFrom-Json -ErrorAction Stop | Out-Null
+        Write-Host "  ok   $($f.Name)" -ForegroundColor Green
+    } catch {
+        $failures.Add("JSON parse failed: $($f.FullName)")
+        Write-Host "  FAIL $($f.Name)" -ForegroundColor Red
+    }
+}
+
+# 3. Python byte-compile
+Write-Section 'Python compile'
+$python = (Get-Command python -ErrorAction SilentlyContinue) ?? (Get-Command python3 -ErrorAction SilentlyContinue)
+if ($python) {
+    foreach ($f in Get-RepoFiles '*.py') {
+        & $python.Source -m py_compile $f.FullName 2>&1 | Out-Null
+        if ($LASTEXITCODE -eq 0) {
+            Write-Host "  ok   $($f.Name)" -ForegroundColor Green
+        } else {
+            $failures.Add("Python compile failed: $($f.FullName)")
+            Write-Host "  FAIL $($f.Name)" -ForegroundColor Red
+        }
+    }
+} else {
+    $warnings.Add('Python not found; skipped Python compile checks.')
+    Write-Host '  (python not found - skipped)' -ForegroundColor Yellow
+}
+
+# 4. .NET build
+Write-Section '.NET build (dotnet/Desktop)'
+$sln = Join-Path $repoRoot 'dotnet/Desktop/Purview API Explorer.sln'
+if ($SkipDotnetBuild) {
+    Write-Host '  (skipped via -SkipDotnetBuild)' -ForegroundColor Yellow
+} elseif (-not (Get-Command dotnet -ErrorAction SilentlyContinue)) {
+    $warnings.Add('dotnet SDK not found; skipped .NET build.')
+    Write-Host '  (dotnet not found - skipped)' -ForegroundColor Yellow
+} else {
+    dotnet build $sln -nologo --verbosity quiet 2>&1 | Out-Null
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host '  ok   Purview API Explorer.sln' -ForegroundColor Green
+    } else {
+        $warnings.Add('dotnet build failed (often offline NuGet restore); re-run with network. Not treated as a hard failure here.')
+        Write-Host '  WARN dotnet build failed (see docs/build-and-test.md)' -ForegroundColor Yellow
+    }
+}
+
+# Summary
+Write-Section 'Summary'
+foreach ($w in $warnings) { Write-Host "WARN: $w" -ForegroundColor Yellow }
+if ($failures.Count -gt 0) {
+    foreach ($x in $failures) { Write-Host "FAIL: $x" -ForegroundColor Red }
+    Write-Host "`nverify.ps1: FAILED ($($failures.Count) error(s))" -ForegroundColor Red
+    Pop-Location
+    exit 1
+}
+Write-Host "`nverify.ps1: PASSED" -ForegroundColor Green
+Pop-Location
+exit 0


### PR DESCRIPTION
## NPF Readiness — Tier 1 baseline adoption (dscgp)

Onboards `microsoft/purview-api-samples` to the NPF readiness pattern at the
**Tier 1 (baseline_ready)** level. This repo is a multi-sample collection of
independent Microsoft Purview developer samples, so the baseline is scoped to
repo-level routing, conventions, and a non-deploying verify loop.

### What this PR adds (7 Tier 1 artifacts)

- `AGENTS.md` — repo router / table of contents for humans and coding agents.
- `.github/copilot-instructions.md` — agent guardrails for small, scoped PRs.
- `.github/instructions/telemetry.instructions.md` — canonical PR/work-item
  telemetry tagging block (byte-identical to the canonical source; only
  per-repo frontmatter added).
- `agency.toml` — agent/skill manifest for the repo.
- `docs/conventions.md` — observed code-style and structure conventions.
- `docs/build-and-test.md` — per-sample build/test/run commands.
- `scripts/verify.ps1` — repo-level verify loop (parses PowerShell, byte-checks
  JSON, compiles Python, builds the WPF solution when the .NET SDK is present).

### Validation

`scripts/verify.ps1` was run against the branch — verify loop PASSED. All seven
Tier 1 artifacts are present and the telemetry block matches the canonical
source.

### Notes for reviewers

- No CI pipeline and no single buildable service exist; verification is the
  non-deploying `scripts/verify.ps1` loop.
- No tenant IDs, client secrets, or cloud credentials are introduced — examples
  use placeholders only.
- This is a draft onboarding PR. Readiness is **not** claimed until this PR is
  merged to `main`; tracker stats are published separately after merge.

---

source-skill: skill:npf-readiness-adopt
source-org: org:dscgp
source-tier: baseline_ready (Tier 1)

<!-- BEGIN pr-telemetry -->
assistance: agentic-cli
type: docs
agent-tool: copilot-cli
agent-model: n/a
work-item: AB#n/a
<!-- END pr-telemetry -->
